### PR TITLE
Fix styles

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -10,6 +10,7 @@ html, body, #root {
     height: 100%;
     margin: 0;
     padding: 0;
+    background-color:$bcg-dark;
 }
 
 body {
@@ -158,10 +159,6 @@ body {
     flex-shrink: 0;
     flex-grow: 0;
     border-left: 1px solid #20292b;
-}
-
-.render-canvas-container {
-    background-color: $bcg-dark;
 }
 
 #file-tabs-container {


### PR DESCRIPTION
The root element's background color specifier had been removed in the latest update resulting in occasional styling issues.